### PR TITLE
Enable local development without needing Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
-# React Compose
+# Bill Tracker
 
-A starter project which contains a fresh `create-react-app` project, ready with
-run with Docker Compose and a Makefile.
+A yearly compendium of bills in the New York State Senate.
 
 ## Requirements
 
 Docker & Docker Compose
 
-## Development
+You will also need an [API key](https://legislation.nysenate.gov/). At the root of this project, create a `.env` file and paste your key like so:
+
+```
+OPEN_LEGISLATION_KEY=asdlkfjaskldjflkasjdflkasjflkjadslfkj
+```
+
+## Development with Docker
 
 - Run `make dev` at the root of this project.
 - Visit the app at [http://localhost:3000](http://localhost:3000).
-- Make your code changes! The app should be live-reloaded whenever you save.
+- Make your code changes! Only the frontend will be live-reloaded whenever you save.
+
+## Development with Node locally
+
+- make a duplicate `.env` file in `backend`
+- make sure you have [redis](https://redis.io/) running: `redis-cli ping`
+- in `backend`, run `npm i` and then `npm run dev`
+- in `frontend`, run `npm i` and then `npm start` and hit Enter when prompted about ports
+- visit the app at [http://localhost:3001](http://localhost:3001)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -470,6 +470,15 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1476,6 +1485,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "cors": "^2.8.5",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,10 +21,11 @@ services:
     environment:
       DEBUG: 'app'
       OPEN_LEGISLATION_KEY: ${OPEN_LEGISLATION_KEY}
+      NODE_ENV: 'docker'
     volumes:
       - './backend/src:/srv/src'
     ports:
-      - '3001:3001'
+      - '3001:3000'
 
   redis:
     image: 'redis:6'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
   "eslintConfig": {
     "extends": "react-app"
   },
-  "proxy": "http://backend:3001",
+  "proxy": "http://backend:3000",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/frontend/src/components/BillList.js
+++ b/frontend/src/components/BillList.js
@@ -15,8 +15,9 @@ export default function BillList() {
 
       const paginateBills = async() => {
         let start = 0
+        let api = 'http://localhost:3000/api/v1/bills/' // TODO: make formal production environment
         do {
-          const res = await fetch(`/api/v1/bills/2019?start=${start}`);
+          const res = await fetch(api + `2019?start=${start}`);
           const {bills, end} = await res.json();
           await setBills((prevBills) => [...prevBills].concat(bills));
           start = end


### PR DESCRIPTION
Allows you to easily run the code with `npm` instead of Docker. Docker live-reloads changes to the frontend, but did not for the backend.

Some of this isn't ideal - I'm worried it will contribute to spaghettification - but it works for now. The code is based on the [muckrock local support](https://github.com/astoria-tech/50-a-foil-status).

---

Some notes for future Elliott:
- Topics: Docker, docker-compose, `package.json` proxies, and React's default env. 
- One of the key points was changing the ports in the `docker-compose`
- Muckrock has checks for `NODE_ENV` on the frontend, but it `npm start` on a `create-react-app` project is always in "development" mode
    - Can resolve this in the future by using `npm build` & actually using our prod Dockerfile
- Not a big fan of setting `NODE_ENV: 'docker'` in the `docker-compose`. I do this because redis on Docker needs different args.