### PR TITLE
Fixes: going over memory cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,27 @@
-# React Compose
+# Bill Tracker
 
-A starter project which contains a fresh `create-react-app` project, ready with
-run with Docker Compose and a Makefile.
+A yearly compendium of bills in the New York State Senate.
 
 ## Requirements
 
 Docker & Docker Compose
 
-## Development
+You will also need an [API key](https://legislation.nysenate.gov/). At the root of this project, create a `.env` file and paste your key like so:
+
+```
+OPEN_LEGISLATION_KEY=asdlkfjaskldjflkasjdflkasjflkjadslfkj
+```
+
+## Development with Docker
 
 - Run `make dev` at the root of this project.
 - Visit the app at [http://localhost:3000](http://localhost:3000).
-- Make your code changes! The app should be live-reloaded whenever you save.
+- Make your code changes! Only the frontend will be live-reloaded whenever you save.
+
+## Development with Node locally
+
+- make a duplicate `.env` file in `backend`
+- make sure you have [redis](https://redis.io/) running: `redis-cli ping`
+- in `backend`, run `npm i` and then `npm run dev`
+- in `frontend`, run `npm i` and then `npm start` and hit Enter when prompted about ports
+- visit the app at [http://localhost:3001](http://localhost:3001)

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "src/app.js",
   "scripts": {
     "start": "node src/app.js",
-    "dev": "nodemon src/app.js --unhandled-rejections=strict"
+    "dev": "nodemon --unhandled-rejections=strict src/app.js"
   },
   "author": "",
   "license": "MIT",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -17,7 +17,7 @@ const redisGet = promisify(redisClient.get).bind(redisClient);
 const redisSetEx = promisify(redisClient.setex).bind(redisClient);
 
 // Global constants
-const REDIS_CACHE_TIME = 600; // NOTE: redis counts seconds, NOT milliseconds
+const REDIS_CACHE_TIME = 60 * 60 * 6; // seconds
 const BILL_PAGE_SIZE = 3000;
 
 // Format the URL with the key and given offset

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -82,6 +82,7 @@ app.get('/api/v1/bills/:year/:printNumber', async (req, res) => {
 const resetCache = async() => {
   console.log('resetting cache automatically');
   const years = [2019, 2020];
+  let nextCacheResetTime = REDIS_CACHE_TIME * 1000; // JS expects ms
   for (let i = 0; i < years.length; i++) {
     const year = years[i];
     console.log(`fetching bills for year ${year}`);
@@ -90,11 +91,14 @@ const resetCache = async() => {
     } catch (error) {
       console.error(`Error fetching bills for year ${year}`);
       console.error(error);
+      // If it failed, try again in a few minutes.
+      nextCacheResetTime = 600 * 1000;
+      break;
     }
   }
   
   // reset cache again in a set amount of time
-  setTimeout(resetCache, REDIS_CACHE_TIME * 1000);
+  setTimeout(resetCache, nextCacheResetTime);
 };
 
 // Listen

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -52,10 +52,7 @@ const requestBillsFromAPI = async(year) => {
 const getBillsWithCache = async(year) => {
   const cachedBills = await redisGet(year);
   if (cachedBills && cachedBills.length > 0) return JSON.parse(cachedBills);
-
-  console.log('resetting cache manually');
-  let allBills = await requestBillsFromAPI(year);
-  return allBills;
+  else return [];
 };
 
 // Endpoint to get all the bills in a year

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -32,8 +32,7 @@ const requestBillsFromAPI = async(year) => {
     let firstResponseData = await firstResponse.json();
 
   if (!firstResponseData.success) {
-    console.error('Did not successfully retrieve bills from legislation.nysenate.gov');
-    return [];
+    throw('Did not successfully retrieve bills from legislation.nysenate.gov. Response from API was marked as a failure.');
   }
 
     // Retrieve the remaining pages

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -95,7 +95,7 @@ const resetCache = async() => {
   }
   
   // reset cache again in a set amount of time
-  setInterval(resetCache, REDIS_CACHE_TIME * 1000);
+  setTimeout(resetCache, REDIS_CACHE_TIME * 1000);
 };
 
 // Listen

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,8 @@ services:
       - './backend/src:/srv/src'
     ports:
       - '3001:3001'
+    depends_on:
+      - redis
 
   redis:
     image: 'redis:6'

--- a/frontend/src/components/BillList.js
+++ b/frontend/src/components/BillList.js
@@ -11,8 +11,6 @@ export default function BillList() {
   const [currentFilter, setFilter] = useState('SIGNED_BY_GOV')
 
   useEffect(() => {
-    if (bills.length === 0) {
-
       const paginateBills = async() => {
         let start = 0
         do {
@@ -23,8 +21,7 @@ export default function BillList() {
         } while (start > 0)
       }
       paginateBills()
-    }
-  });
+  }, []); // Only run on initial page load
 
   let filteredBills = bills.filter(x => {
     return (


### PR DESCRIPTION
A lot of minor fixes, and one major one.

The big one is changin my async call from `setInterval` to `setTimeout`. No wonder we were running out of memory, each iteration of the call made a new async `setInterval` stack! Bit of a silly mistake.

For the other changes, the commit messages should tell you what you need to know. I will monitor this PR's performance in Shipyard over the weekend.