### PR TITLE
Remove 'police' from title & description

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>NYS Police Reform</title>
+    <title>NYS Bill Tracker</title>
 
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&family=Fjalla+One&display=swap"

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -11,13 +11,12 @@ const Header = () => {
             <use xlinkHref={`${Icons}#icon--bill`} />
           </svg>
           <h1 className="site-header__text">
-            New York State Bill Tracker for Police Reform
+            New York State Bill Tracker
           </h1>
         </div>
         <div className="site-header__slogan">
           <p>
-            Easily track the progress of NY State legistation package for police
-            reform.
+            Easily track the progress of New York State legistation packages.
           </p>
         </div>
         <a className="site-header__contact" href="mailto:team@astoria.digital">


### PR DESCRIPTION
Remove "police reform" from title and description at top of Bill Tracker page